### PR TITLE
Exposing scannedImageDuration to SDK

### DIFF
--- a/CardIO_Public_API/CardIOPaymentViewController.h
+++ b/CardIO_Public_API/CardIOPaymentViewController.h
@@ -76,6 +76,13 @@
 /// Defaults to NO.
 @property(nonatomic, assign, readwrite) BOOL suppressScannedCardImage;
 
+/// After a successful scan, card.io will display an image of the card with
+/// the computed card number superimposed. This property controls how long (in seconds)
+/// that image will be displayed.
+/// Set this to 0.0 to suppress the display entirely.
+/// Defaults to 0.1.
+@property(nonatomic, assign, readwrite) CGFloat scannedImageDuration;
+
 /// Mask the card number digits as they are manually entered by the user. Defaults to NO.
 @property(nonatomic, assign, readwrite) BOOL maskManualEntryDigits;
 

--- a/Classes/CardIOContext.h
+++ b/Classes/CardIOContext.h
@@ -28,7 +28,6 @@
 @property(nonatomic, assign, readwrite) BOOL suppressScannedCardImage;
 @property(nonatomic, assign, readwrite) BOOL maskManualEntryDigits;
 
-
 #if CARDIO_DEBUG
 @property(nonatomic, assign, readwrite) BOOL doABTesting;
 #endif
@@ -38,6 +37,7 @@
 @property(nonatomic, copy, readwrite)   NSString *languageOrLocale;
 @property(nonatomic, assign, readwrite) BOOL useCardIOLogo;
 @property(nonatomic, retain, readwrite) UIColor *guideColor;
+@property(nonatomic, assign, readwrite) CGFloat scannedImageDuration;
 @property(nonatomic, assign, readwrite) BOOL allowFreelyRotatingCardGuide;
 
 @property(nonatomic, copy, readwrite)   NSString *scanInstructions;

--- a/Classes/CardIOContext.m
+++ b/Classes/CardIOContext.m
@@ -37,6 +37,7 @@ CONFIG_PASSTHROUGH_READWRITE(CardIOAnalytics *, scanReport, ScanReport)
 CONFIG_PASSTHROUGH_READWRITE(NSString *, languageOrLocale, LanguageOrLocale)
 CONFIG_PASSTHROUGH_READWRITE(BOOL, useCardIOLogo, UseCardIOLogo)
 CONFIG_PASSTHROUGH_READWRITE(UIColor *, guideColor, GuideColor)
+CONFIG_PASSTHROUGH_READWRITE(CGFloat, scannedImageDuration, ScannedImageDuration)
 CONFIG_PASSTHROUGH_READWRITE(BOOL, allowFreelyRotatingCardGuide, AllowFreelyRotatingCardGuide)
 
 CONFIG_PASSTHROUGH_READWRITE(NSString *, scanInstructions, ScanInstructions)

--- a/Classes/CardIOPaymentViewController.m
+++ b/Classes/CardIOPaymentViewController.m
@@ -77,6 +77,7 @@
 
   if((self = [super initWithRootViewController:viewController])) {
     _context = context;
+    _context.scannedImageDuration = 0.1;
     _currentViewControllerIsDataEntry = [viewController isKindOfClass:[CardIODataEntryViewController class]];
     _initialInterfaceOrientationForViewcontroller = [UIApplication sharedApplication].statusBarOrientation;
 #if USE_CAMERA || SIMULATE_CAMERA
@@ -389,6 +390,7 @@ CONTEXT_PASSTHROUGH_READWRITE(UIColor *, guideColor, GuideColor)
 CONTEXT_PASSTHROUGH_READWRITE(BOOL, suppressScanConfirmation, SuppressScanConfirmation)
 CONTEXT_PASSTHROUGH_READWRITE(BOOL, suppressScannedCardImage, SuppressScannedCardImage)
 CONTEXT_PASSTHROUGH_READWRITE(BOOL, maskManualEntryDigits, MaskManualEntryDigits)
+CONTEXT_PASSTHROUGH_READWRITE(CGFloat, scannedImageDuration, ScannedImageDuration)
 CONTEXT_PASSTHROUGH_READWRITE(BOOL, allowFreelyRotatingCardGuide, AllowFreelyRotatingCardGuide)
 
 CONTEXT_PASSTHROUGH_GETTER(CardIOAnalytics *, scanReport)

--- a/Classes/CardIOViewController.mm
+++ b/Classes/CardIOViewController.mm
@@ -98,7 +98,7 @@
   self.cardIOView.useCardIOLogo = self.context.useCardIOLogo;
   self.cardIOView.hideCardIOLogo = self.context.hideCardIOLogo;
   self.cardIOView.guideColor = self.context.guideColor;
-  self.cardIOView.scannedImageDuration = ((CGFloat) 0.1f);
+  self.cardIOView.scannedImageDuration = self.context.scannedImageDuration;
   self.cardIOView.allowFreelyRotatingCardGuide = self.context.allowFreelyRotatingCardGuide;
 
   self.cardIOView.scanInstructions = self.context.scanInstructions;

--- a/Classes/RootViewController.m
+++ b/Classes/RootViewController.m
@@ -36,6 +36,7 @@
 @property(nonatomic, strong, readwrite) IBOutlet UISwitch *useCardIOLogoSwitch;
 @property(nonatomic, strong, readwrite) IBOutlet UISwitch *doABTestingSwitch;
 @property(nonatomic, strong, readwrite) IBOutlet UISegmentedControl *modalPresentationStyleSegment;
+@property(nonatomic, strong, readwrite) IBOutlet UITextField *scannedImageDurationField;
 @property(nonatomic, strong, readwrite) IBOutlet CardIOView *hideableCardIOView;
 
 @property(nonatomic, strong, readwrite) IBOutlet UIButton *languageButton;
@@ -81,6 +82,7 @@
   paymentVC.disableManualEntryButtons = self.disableManualEntrySwitch.on;
   paymentVC.useCardIOLogo = self.useCardIOLogoSwitch.on;
   paymentVC.allowFreelyRotatingCardGuide = NO;
+  paymentVC.scannedImageDuration = [self.scannedImageDurationField.text floatValue];
 #if CARDIO_DEBUG
   paymentVC.doABTesting = self.doABTestingSwitch.on;
 #endif

--- a/Classes/RootViewController.xib
+++ b/Classes/RootViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6250" systemVersion="13F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="RootViewController">
@@ -22,6 +22,7 @@
                 <outlet property="redactSwitch" destination="74" id="78"/>
                 <outlet property="scanButton" destination="4" id="51"/>
                 <outlet property="scanPicoPikaButton" destination="RrX-uf-xXq" id="Nai-4s-uGL"/>
+                <outlet property="scannedImageDurationField" destination="PmQ-6L-xIv" id="HTN-OC-Zid"/>
                 <outlet property="useCardIOLogoSwitch" destination="79" id="81"/>
                 <outlet property="view" destination="1" id="3"/>
                 <outlet property="zipSwitch" destination="39" id="42"/>
@@ -33,7 +34,7 @@
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <subviews>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="RrX-uf-xXq">
-                    <rect key="frame" x="0.0" y="214" width="114" height="44"/>
+                    <rect key="frame" x="0.0" y="238" width="114" height="33"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="18"/>
                     <state key="normal" title="Scan (view)" backgroundImage="green_button.png">
@@ -48,7 +49,7 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="4">
-                    <rect key="frame" x="115" y="214" width="102" height="44"/>
+                    <rect key="frame" x="115" y="237" width="102" height="34"/>
                     <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="18"/>
                     <state key="normal" title="Scan (vc)" backgroundImage="green_button.png">
                         <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
@@ -62,7 +63,7 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="86">
-                    <rect key="frame" x="220" y="214" width="100" height="44"/>
+                    <rect key="frame" x="220" y="238" width="100" height="33"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="18"/>
                     <state key="normal" title="I18n test" backgroundImage="yellow_button.png">
@@ -190,13 +191,13 @@
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                 </imageView>
                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="none" adjustsFontSizeToFit="NO" id="34">
-                    <rect key="frame" x="20" y="260" width="280" height="200"/>
+                    <rect key="frame" x="20" y="272" width="280" height="200"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="14"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <view hidden="YES" contentMode="scaleToFill" id="GDb-46-Doh" customClass="CardIOView">
-                    <rect key="frame" x="50" y="266.00000021696098" width="220" height="200"/>
+                    <rect key="frame" x="50" y="272" width="220" height="200"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                 </view>
@@ -210,6 +211,18 @@
                         <action selector="languageChangeAction:" destination="-1" eventType="touchUpInside" id="oKR-q8-phq"/>
                     </connections>
                 </button>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Duration" lineBreakMode="tailTruncation" minimumFontSize="10" id="nB6-3I-aqn">
+                    <rect key="frame" x="7" y="209" width="73" height="21"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="17"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="1.0" borderStyle="roundedRect" minimumFontSize="17" id="PmQ-6L-xIv">
+                    <rect key="frame" x="93" y="205" width="53" height="30"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <textInputTraits key="textInputTraits"/>
+                </textField>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <nil key="simulatedStatusBarMetrics"/>

--- a/Classes/RootViewController~ipad.xib
+++ b/Classes/RootViewController~ipad.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.iPad.XIB" version="3.0" toolsVersion="6250" systemVersion="13F34" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.iPad.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="RootViewController">
@@ -23,6 +23,7 @@
                 <outlet property="redactSwitch" destination="107" id="121"/>
                 <outlet property="scanButton" destination="88" id="122"/>
                 <outlet property="scanPicoPikaButton" destination="3Kl-dy-lyY" id="Kya-w4-0Kx"/>
+                <outlet property="scannedImageDurationField" destination="CGB-UR-aum" id="kiv-iw-xRN"/>
                 <outlet property="useCardIOLogoSwitch" destination="131" id="133"/>
                 <outlet property="view" destination="1" id="3"/>
                 <outlet property="zipSwitch" destination="99" id="123"/>
@@ -209,7 +210,7 @@
                     </connections>
                 </button>
                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="" lineBreakMode="tailTruncation" numberOfLines="0" minimumFontSize="10" id="97">
-                    <rect key="frame" x="177" y="503.99997593491287" width="415" height="205"/>
+                    <rect key="frame" x="177" y="504" width="415" height="205"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES"/>
                     <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="17"/>
                     <nil key="highlightedColor"/>
@@ -233,6 +234,18 @@
                         <action selector="languageChangeAction:" destination="-1" eventType="touchUpInside" id="Xra-XV-D9I"/>
                     </connections>
                 </button>
+                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="1.0" borderStyle="roundedRect" minimumFontSize="17" id="CGB-UR-aum">
+                    <rect key="frame" x="278" y="203" width="53" height="30"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <textInputTraits key="textInputTraits"/>
+                </textField>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Duration" lineBreakMode="tailTruncation" minimumFontSize="10" id="RH3-Nd-yFd">
+                    <rect key="frame" x="192" y="207" width="73" height="21"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="17"/>
+                    <nil key="highlightedColor"/>
+                </label>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <nil key="simulatedStatusBarMetrics"/>


### PR DESCRIPTION
There was no way to reduce scanned image duration to 0 seconds, so there was always a flash of the card numbers on the screen. We had a client request that the numbers are never shown in that manner, so I exposed that value to the SDK.