### PR TITLE
Add option for only numeric input for postal code

### DIFF
--- a/CardIO_Public_API/CardIOPaymentViewController.h
+++ b/CardIO_Public_API/CardIOPaymentViewController.h
@@ -129,6 +129,9 @@
 /// Set to YES if you need to collect the billing postal code. Defaults to NO.
 @property(nonatomic, assign, readwrite) BOOL collectPostalCode;
 
+/// Set to YES if the postal code should only collect numeric input. Defaults to NO.
+@property(nonatomic, assign, readwrite) BOOL restrictPostalCodeToNumericOnly;
+
 /// Set to YES if you need to collect the cardholder name. Defaults to NO.
 @property(nonatomic, assign, readwrite) BOOL collectCardholderName;
 

--- a/CardIO_Public_API/CardIOPaymentViewController.h
+++ b/CardIO_Public_API/CardIOPaymentViewController.h
@@ -129,7 +129,9 @@
 /// Set to YES if you need to collect the billing postal code. Defaults to NO.
 @property(nonatomic, assign, readwrite) BOOL collectPostalCode;
 
-/// Set to YES if the postal code should only collect numeric input. Defaults to NO.
+/// Set to YES if the postal code should only collect numeric input. Defaults to NO. Set this if you know the
+/// <a href="https://en.wikipedia.org/wiki/Postal_code">expected country's postal code</a> has only numeric postal
+/// codes.
 @property(nonatomic, assign, readwrite) BOOL restrictPostalCodeToNumericOnly;
 
 /// Set to YES if you need to collect the cardholder name. Defaults to NO.

--- a/Classes/CardIOContext.h
+++ b/Classes/CardIOContext.h
@@ -19,6 +19,7 @@
 @property(nonatomic, assign, readwrite) BOOL collectCVV;
 @property(nonatomic, assign, readwrite) BOOL collectExpiry;
 @property(nonatomic, assign, readwrite) BOOL collectPostalCode;
+@property(nonatomic, assign, readwrite) BOOL restrictPostalCodeToNumericOnly;
 @property(nonatomic, assign, readwrite) BOOL collectCardholderName;
 @property(nonatomic, assign, readwrite) BOOL disableManualEntryButtons;
 @property(nonatomic, assign, readwrite) BOOL keepStatusBarStyle;

--- a/Classes/CardIODataEntryViewController.h
+++ b/Classes/CardIODataEntryViewController.h
@@ -27,6 +27,7 @@
 @property(nonatomic, assign, readwrite) BOOL collectExpiry;
 @property(nonatomic, assign, readwrite) BOOL collectCVV;
 @property(nonatomic, assign, readwrite) BOOL collectPostalCode;
+@property(nonatomic, assign, readwrite) BOOL restrictPostalCodeToNumericOnly;
 @property(nonatomic, assign, readwrite) BOOL collectCardholderName;
 @property(nonatomic, strong, readwrite) UITextField *expiryTextField;
 @property(nonatomic, strong, readwrite) UITextField *numberTextField;

--- a/Classes/CardIODataEntryViewController.m
+++ b/Classes/CardIODataEntryViewController.m
@@ -151,6 +151,7 @@
   self.collectExpiry = pvc.collectExpiry;
   self.collectCVV = pvc.collectCVV;
   self.collectPostalCode = pvc.collectPostalCode;
+  self.restrictPostalCodeToNumericOnly = pvc.restrictPostalCodeToNumericOnly;
   self.collectCardholderName = pvc.collectCardholderName;
 
   self.scrollView = [[UIScrollView alloc] initWithFrame:self.relevantViewFrame];
@@ -312,7 +313,12 @@
     self.postalCodeTextField.placeholder = postalCodeText;
     self.postalCodeTextField.delegate = self.postalCodeRowTextFieldDelegate;
     self.postalCodeTextField.text = self.cardInfo.postalCode;
-    self.postalCodeTextField.keyboardType = UIKeyboardTypeNumbersAndPunctuation;
+    if (self.restrictPostalCodeToNumericOnly) {
+      self.postalCodeTextField.keyboardType = UIKeyboardTypeNumberPad;
+      self.postalCodeRowTextFieldDelegate.numbersOnly = YES;
+    } else {
+      self.postalCodeTextField.keyboardType = UIKeyboardTypeNumbersAndPunctuation;
+    }
     self.postalCodeTextField.clearButtonMode = UITextFieldViewModeNever;
     self.postalCodeTextField.text = @"";
     self.postalCodeTextField.textAlignment = [CardIOLocalizer textAlignmentForLanguageOrLocale:self.context.languageOrLocale];

--- a/Classes/CardIOPaymentViewController.m
+++ b/Classes/CardIOPaymentViewController.m
@@ -340,7 +340,7 @@
 #define DESCRIBE_BOOL(property) (self.property ? "; " #property : "")
 
 - (NSString *)description {
-  return [NSString stringWithFormat:@"{delegate: %@; %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s}"
+  return [NSString stringWithFormat:@"{delegate: %@; %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s}"
           ,self.paymentDelegate
           ,DESCRIBE_BOOL(keepStatusBarStyle)
           ,DESCRIBE_BOOL(disableBlurWhenBackgrounding)
@@ -351,6 +351,7 @@
           ,DESCRIBE_BOOL(collectCVV)
           ,DESCRIBE_BOOL(collectPostalCode)
           ,DESCRIBE_BOOL(collectCardholderName)
+          ,DESCRIBE_BOOL(restrictPostalCodeToNumericOnly)
           ,DESCRIBE_BOOL(scanExpiry)
           ,DESCRIBE_BOOL(useCardIOLogo)
           ,DESCRIBE_BOOL(disableManualEntryButtons)
@@ -388,6 +389,7 @@ CONTEXT_PASSTHROUGH_READWRITE(UIColor *, navigationBarTintColor, NavigationBarTi
 CONTEXT_PASSTHROUGH_READWRITE(BOOL, disableBlurWhenBackgrounding, DisableBlurWhenBackgrounding)
 CONTEXT_PASSTHROUGH_READWRITE(BOOL, collectCVV, CollectCVV)
 CONTEXT_PASSTHROUGH_READWRITE(BOOL, collectPostalCode, CollectPostalCode)
+CONTEXT_PASSTHROUGH_READWRITE(BOOL, restrictPostalCodeToNumericOnly, RestrictPostalCodeToNumericOnly)
 CONTEXT_PASSTHROUGH_READWRITE(BOOL, collectCardholderName, CollectCardholderName)
 CONTEXT_PASSTHROUGH_READWRITE(BOOL, collectExpiry, CollectExpiry)
 CONTEXT_PASSTHROUGH_READWRITE(BOOL, scanExpiry, ScanExpiry)

--- a/Classes/RootViewController.m
+++ b/Classes/RootViewController.m
@@ -26,6 +26,7 @@
 @property(nonatomic, strong, readwrite) IBOutlet UISwitch *expirySwitch;
 @property(nonatomic, strong, readwrite) IBOutlet UISwitch *cvvSwitch;
 @property(nonatomic, strong, readwrite) IBOutlet UISwitch *zipSwitch;
+@property(nonatomic, strong, readwrite) IBOutlet UISwitch *zipOnlyNumericSwitch;
 @property(nonatomic, strong, readwrite) IBOutlet UISwitch *nameSwitch;
 @property(nonatomic, strong, readwrite) IBOutlet UILabel *outcomeLabel;
 @property(nonatomic, strong, readwrite) IBOutlet UIImageView *cardImageView;
@@ -80,6 +81,7 @@
   paymentVC.collectExpiry = self.expirySwitch.on;
   paymentVC.collectCVV = self.cvvSwitch.on;
   paymentVC.collectPostalCode = self.zipSwitch.on;
+  paymentVC.restrictPostalCodeToNumericOnly = self.zipOnlyNumericSwitch.on;
   paymentVC.collectCardholderName = self.nameSwitch.on;
   paymentVC.disableManualEntryButtons = self.disableManualEntrySwitch.on;
   paymentVC.useCardIOLogo = self.useCardIOLogoSwitch.on;
@@ -422,6 +424,9 @@
   }
   if(self.zipSwitch.on) {
     [resultStr appendFormat:@"Postal Code: %@\n", info.postalCode];
+  }
+  if(self.zipOnlyNumericSwitch.on) {
+    [resultStr appendFormat:@"Postal Code Only Numeric: %@\n", info.postalCode];
   }
   if(self.nameSwitch.on) {
     [resultStr appendFormat:@"Cardholder Name: %@\n", info.cardholderName];

--- a/Classes/RootViewController.xib
+++ b/Classes/RootViewController.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9060" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="RootViewController">
@@ -25,6 +25,7 @@
                 <outlet property="scannedImageDurationField" destination="PmQ-6L-xIv" id="HTN-OC-Zid"/>
                 <outlet property="useCardIOLogoSwitch" destination="79" id="81"/>
                 <outlet property="view" destination="1" id="3"/>
+                <outlet property="zipOnlyNumericSwitch" destination="cMt-1g-pbE" id="zSn-eU-A9V"/>
                 <outlet property="zipSwitch" destination="39" id="42"/>
             </connections>
         </placeholder>
@@ -34,7 +35,7 @@
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <subviews>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="RrX-uf-xXq">
-                    <rect key="frame" x="0.0" y="238" width="114" height="33"/>
+                    <rect key="frame" x="0.0" y="269" width="114" height="33"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="18"/>
                     <state key="normal" title="Scan (view)" backgroundImage="green_button.png">
@@ -49,7 +50,7 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="4">
-                    <rect key="frame" x="115" y="237" width="102" height="34"/>
+                    <rect key="frame" x="115" y="268" width="102" height="34"/>
                     <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="18"/>
                     <state key="normal" title="Scan (vc)" backgroundImage="green_button.png">
                         <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
@@ -63,7 +64,7 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="86">
-                    <rect key="frame" x="220" y="238" width="100" height="33"/>
+                    <rect key="frame" x="220" y="269" width="100" height="33"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="18"/>
                     <state key="normal" title="I18n test" backgroundImage="yellow_button.png">
@@ -191,18 +192,18 @@
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                 </imageView>
                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="none" adjustsFontSizeToFit="NO" id="34">
-                    <rect key="frame" x="20" y="272" width="280" height="200"/>
+                    <rect key="frame" x="20" y="310" width="280" height="162"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="14"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <view hidden="YES" contentMode="scaleToFill" id="GDb-46-Doh" customClass="CardIOView">
-                    <rect key="frame" x="50" y="272" width="220" height="200"/>
+                    <rect key="frame" x="50" y="327" width="220" height="145"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                 </view>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="headTruncation" id="k3C-XD-Rpp">
-                    <rect key="frame" x="170" y="205" width="135" height="30"/>
+                    <rect key="frame" x="93" y="238" width="135" height="30"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <state key="normal" title="Language [en]">
                         <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -231,6 +232,16 @@
                 </label>
                 <switch opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="MkK-VS-bu9" userLabel="Zip Switch">
                     <rect key="frame" x="255" y="72" width="51" height="31"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                </switch>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Zip # Only" lineBreakMode="tailTruncation" minimumFontSize="10" id="Z7T-Mv-xUo">
+                    <rect key="frame" x="165" y="210" width="99" height="21"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="17"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <switch opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="cMt-1g-pbE" userLabel="Zip Numeric Only Switch">
+                    <rect key="frame" x="255" y="205" width="51" height="31"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                 </switch>
             </subviews>


### PR DESCRIPTION
- Have an option to allow for only numeric postal codes (mainly for easier input).
- This would be the corresponding iOS feature for https://github.com/card-io/card.io-Android-SDK/issues/100