### PR TITLE
Allow user to switch back to scanner when starting with manual entry

### DIFF
--- a/Classes/CardIODataEntryViewController.m
+++ b/Classes/CardIODataEntryViewController.m
@@ -131,15 +131,24 @@
     style = UIBarButtonItemStylePlain;
   }
 
+  NSMutableArray<UIBarButtonItem *> *leftBarButtonItems = [NSMutableArray arrayWithCapacity:2];
+
   if(showCancelButton) {
     NSString *cancelText = CardIOLocalizedString(@"cancel", self.context.languageOrLocale); // Cancel
     // show the cancel button if we've gone directly to manual entry.
-    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:cancelText style:style target:self action:@selector(cancel)];
+    UIBarButtonItem *cancelItem = [[UIBarButtonItem alloc] initWithTitle:cancelText style:style target:self action:@selector(cancel)];
+    [leftBarButtonItems addObject:cancelItem];
+
+    UIBarButtonItem *cameraItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCamera target:self action:@selector(switchToScan)];
+    [leftBarButtonItems addObject:cameraItem];
   } else {
     // Show fake "back" button, since real back button takes us back to the animation view, not back to the camera
     NSString *cameraText = CardIOLocalizedString(@"camera", self.context.languageOrLocale); // Camera
-    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:cameraText style:style target:self action:@selector(popToTop)];
+    UIBarButtonItem *cameraItem = [[UIBarButtonItem alloc] initWithTitle:cameraText style:style target:self action:@selector(popToTop)];
+    [leftBarButtonItems addObject:cameraItem];
   }
+
+  self.navigationItem.leftBarButtonItems = leftBarButtonItems;
 
   NSString *cardInfoText = CardIOLocalizedString(@"card_info", self.context.languageOrLocale); // Card Info
   self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:cardInfoText style:style target:nil action:nil];
@@ -781,6 +790,14 @@
 }
 
 #pragma mark -
+
+- (void)switchToScan {
+  CardIOPaymentViewController *root = (CardIOPaymentViewController *)self.navigationController;
+  UIViewController *vc = [CardIOPaymentViewController viewControllerWithScanningEnabled:YES withContext:self.context];
+  root.viewControllers = @[vc, self];
+  root.currentViewControllerIsDataEntry = YES;
+  [self popToTop];
+}
 
 - (void)popToTop {
   if (iOS_7_PLUS) {

--- a/Classes/CardIODataEntryViewController.m
+++ b/Classes/CardIODataEntryViewController.m
@@ -126,18 +126,23 @@
     showCancelButton = YES;
   }
 
+  UIBarButtonItemStyle style = UIBarButtonItemStyleBordered;
+  if (iOS_8_PLUS) {
+    style = UIBarButtonItemStylePlain;
+  }
+
   if(showCancelButton) {
     NSString *cancelText = CardIOLocalizedString(@"cancel", self.context.languageOrLocale); // Cancel
     // show the cancel button if we've gone directly to manual entry.
-    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:cancelText style:UIBarButtonItemStyleBordered target:self action:@selector(cancel)];
+    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:cancelText style:style target:self action:@selector(cancel)];
   } else {
     // Show fake "back" button, since real back button takes us back to the animation view, not back to the camera
     NSString *cameraText = CardIOLocalizedString(@"camera", self.context.languageOrLocale); // Camera
-    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:cameraText style:UIBarButtonItemStyleBordered target:self action:@selector(popToTop)];
+    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:cameraText style:style target:self action:@selector(popToTop)];
   }
 
   NSString *cardInfoText = CardIOLocalizedString(@"card_info", self.context.languageOrLocale); // Card Info
-  self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:cardInfoText style:UIBarButtonItemStyleBordered target:nil action:nil];
+  self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:cardInfoText style:style target:nil action:nil];
 
   NSString *completionButtonTitle = CardIOLocalizedString(@"done", self.context.languageOrLocale); // Done
 
@@ -1007,7 +1012,13 @@
   }
 
   // we are under the assumption of a normal US calendar
-  NSCalendar *cal = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
+  NSString *calenderIdent = nil;
+  if (iOS_7_PLUS) {
+    calenderIdent = NSCalendarIdentifierGregorian;
+  } else {
+    calenderIdent = NSGregorianCalendar;
+  }
+  NSCalendar *cal = [[NSCalendar alloc] initWithCalendarIdentifier:calenderIdent];
 
   NSDateComponents *expiryComponents = [[NSDateComponents alloc] init];
   [expiryComponents setMonth:info.expiryMonth + 1]; // +1 to account for cards expiring "this month"

--- a/Classes/CardIODataEntryViewController.m
+++ b/Classes/CardIODataEntryViewController.m
@@ -795,7 +795,7 @@
   CardIOPaymentViewController *root = (CardIOPaymentViewController *)self.navigationController;
   UIViewController *vc = [CardIOPaymentViewController viewControllerWithScanningEnabled:YES withContext:self.context];
   root.viewControllers = @[vc, self];
-  root.currentViewControllerIsDataEntry = YES;
+  root.currentViewControllerIsDataEntry = NO;
   [self popToTop];
 }
 

--- a/Classes/CardIODataEntryViewController.m
+++ b/Classes/CardIODataEntryViewController.m
@@ -1013,7 +1013,7 @@
 
   // we are under the assumption of a normal US calendar
   NSString *calenderIdent = nil;
-  if (iOS_7_PLUS) {
+  if (iOS_8_PLUS) {
     calenderIdent = NSCalendarIdentifierGregorian;
   } else {
     calenderIdent = NSGregorianCalendar;

--- a/Classes/CardIOPaymentViewControllerContinuation.h
+++ b/Classes/CardIOPaymentViewControllerContinuation.h
@@ -12,6 +12,7 @@
 
 + (CardIOPaymentViewController *)cardIOPaymentViewControllerForResponder:(UIResponder *)responder;
 - (UIInterfaceOrientationMask)supportedOverlayOrientationsMask;
++ (UIViewController *)viewControllerWithScanningEnabled:(BOOL)scanningEnabled withContext:(CardIOContext *)aContext;
 
 @property(nonatomic, assign, readwrite) BOOL currentViewControllerIsDataEntry;
 @property(nonatomic, assign, readwrite) UIInterfaceOrientation initialInterfaceOrientationForViewcontroller;


### PR DESCRIPTION
WIP - Creating placeholder PR, still need to test more, tested on device (iPhone 6S 9.2) and simulator (iPhone 4S 8.1)

This matches functionality in Android PR: https://github.com/card-io/card.io-Android-source/pull/52

Also need to discuss UI, I added a ```UIBarButtonSystemItemCamera``` next to the 'Cancel' button in the ```leftBarButtonItems``` in ```CardIODataEntryViewController``` when the user starts ```CardIOPaymentViewController``` with ```scanningEnabled=NO```, because when I added an item with the word 'Cancel' seemed too squished.  Need some suggestions for how to make the UI, I just winged it.