### PR TITLE
Use HTTPS submodule URL for dmz

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "dmz"]
 	path = dmz
-	url = git@github.com:card-io/card.io-dmz.git
+	url = https://github.com/card-io/card.io-dmz.git


### PR DESCRIPTION
My team is unfortunately working in a network that blocks all SSH connections. We're able to use HTTPS to clone this repo, but unfortunately the dmz submodule still uses SSH, and so we're unable to clone the repo.

Would you consider accepting this change to use HTTPS for the submodule URL?
