### PR TITLE
Skip invalid IplImage from being scanned

### DIFF
--- a/Classes/CardIOVideoFrame.mm
+++ b/Classes/CardIOVideoFrame.mm
@@ -131,10 +131,13 @@
   if(foundCard) {
     IplImage *foundCardY = NULL;
     dmz_transform_card(self.dmz, self.ySample.image, self.corner_points, frameOrientation, false, &foundCardY);
-    self.cardY = [CardIOIplImage imageWithIplImage:foundCardY];
 
-    BOOL scanCard = YES;
-    scanCard = (self.detectionMode != CardIODetectionModeCardImageOnly);
+    BOOL isValidIplImage = (foundCardY != NULL) && (foundCardY->nSize == sizeof(IplImage));
+    if (isValidIplImage) {
+      self.cardY = [CardIOIplImage imageWithIplImage:foundCardY];
+    }
+
+    BOOL scanCard = isValidIplImage && (self.detectionMode != CardIODetectionModeCardImageOnly);
     if(scanCard) {
       [self.scanner addFrame:self.cardY
                   focusScore:self.focusScore


### PR DESCRIPTION
- In very odd but numerous crash reports, there are instances where the IplImage does
  not have a valid header. This could cause a crash notably calling through (reversed stack trace):
  ```
  [CardIOVideoStream sendFrameToDelegate:]
  [CardIOCameraView videoStream:didProcessFrame:]
  [CardIOView videoStream:didProcessFrame:]
  [CardIOView didScanCard:]
  [CardIOVideoFrame imageWithGrayscale:]
  [CardIOIplImage rgbImageWithY:cb:cr:]
  void dmz_YCbCr_to_RGB(IplImage *y, IplImage *cb, IplImage *cr, IplImage **rgb)
  ```
  and eventually calls `cvGetSize()` which throws an exception with
  "Array should be CvMat or IplImage".

  This code tries to detect invalid IplImage values earlier and skips scanning them.