### PR TITLE
Update CardIOVideoStream's previewLayer to CALayer

### DIFF
--- a/Classes/CardIOVideoStream.mm
+++ b/Classes/CardIOVideoStream.mm
@@ -144,7 +144,7 @@
 @property(nonatomic, assign, readwrite) BOOL wasRunningBeforeBeingBackgrounded;
 @property(nonatomic, assign, readwrite) BOOL didEndGeneratingDeviceOrientationNotifications;
 @property(assign, readwrite) UIInterfaceOrientation interfaceOrientation; // intentionally atomic -- video frames are processed on a different thread
-@property(nonatomic, strong, readwrite) AVCaptureVideoPreviewLayer *previewLayer;
+@property(nonatomic, strong, readwrite) CALayer *previewLayer;
 @property(nonatomic, strong, readwrite) AVCaptureSession *captureSession;
 @property(nonatomic, strong, readwrite) AVCaptureDevice *camera;
 @property(nonatomic, strong, readwrite) AVCaptureDeviceInput *cameraInput;


### PR DESCRIPTION
Update CardIOVideoStream's previewLayer to CALayer to allow it to be a SimulatedCameraLayer.

Resolves the following compile error in Xcode 7.3:
```
/card.io-iOS-source/Classes/CardIOVideoStream.mm:189:19: error: assigning to
'AVCaptureVideoPreviewLayer *__strong' from incompatible type 'SimulatedCameraLayer * _Nonnull'
```