### PR TITLE
Updated CardIOVideoStream's delegate to be a UIResponder to fix Xcode 8 compiler error

### DIFF
--- a/Classes/CardIOVideoStream.h
+++ b/Classes/CardIOVideoStream.h
@@ -43,7 +43,7 @@
 
 @property(nonatomic, strong, readwrite) CardIOConfig *config;
 @property(nonatomic, assign, readonly) BOOL running;
-@property(nonatomic, weak, readwrite) id<CardIOVideoStreamDelegate> delegate;
+@property(nonatomic, weak, readwrite) UIResponder<CardIOVideoStreamDelegate> *delegate;
 #if SIMULATE_CAMERA
 @property(nonatomic, strong, readonly) CALayer *previewLayer;
 #else


### PR DESCRIPTION
Detailed explanation of this change is in issue https://github.com/card-io/card.io-iOS-source/issues/69