### PR TITLE
Use HTTPS URL for submodule to allow read access for non GH users

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "dmz"]
 	path = dmz
-	url = git@github.com:card-io/card.io-dmz.git
+	url = https://github.com/card-io/card.io-dmz.git


### PR DESCRIPTION
This is required to be able to clone the repository and its submodules without having a GitHub account. An example use case is consuming card.io through carthage to build an iOS application within a large team of engineers where people simply cannot be required to sign up for GitHub and upload their SSH key just to build the app.

See also https://github.com/Carthage/Carthage/issues/1865